### PR TITLE
chore: removed duplicate URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://github.com/jasonmerino/react-native-simple-store
 # realm-react-native/
 Realm React Native enables you to efficiently write your app’s model layer in a safe, persisted and fast way. Here’s what it looks like: See Realm React Native and Docs For Realm
 read more
-https://realm.io/news/introducing-realm-react-native/
+https://www.mongodb.com/docs/realm/sdk/react-native/realm-database/
 
 # react-native-local-mongodb
 Embedded persistent or in memory database for react-native. API is a subset of MongoDB's (NeDB) and it's plenty fast.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ https://github.com/jasonmerino/react-native-simple-store
 Realm React Native enables you to efficiently write your app’s model layer in a safe, persisted and fast way. Here’s what it looks like: See Realm React Native and Docs For Realm
 read more
 https://realm.io/news/introducing-realm-react-native/
-https://realm.io/news/introducing-realm-react-native/
 
 # react-native-local-mongodb
 Embedded persistent or in memory database for react-native. API is a subset of MongoDB's (NeDB) and it's plenty fast.


### PR DESCRIPTION
Removed duplicate of https://blog.realm.io/blog/introducing-realm-react-native/.
Also, the URL was down. Replaced with https://www.mongodb.com/docs/realm/sdk/react-native/realm-database/